### PR TITLE
Limiting FastAPI to `<1` instead of `<0.99.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "fastapi_standalone_docs"}]
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"
-fastapi = ">=0.95.2,<0.99.0"
+fastapi = ">=0.95.2,<1"
 
 [tool.poetry.scripts]
 update-fastapi-standalone-docs = { callable = "fastapi_standalone_docs.scripts:update_docs", extras = ["scripts"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-standalone-docs"
-version = "0.1.3"
+version = "0.1.4"
 description = "Host FastAPI Swagger UI and ReDoc without third party CDNs"
 authors = ["IOXIO Ltd"]
 license = "MIT"


### PR DESCRIPTION
FastAPI is currently on `0.100.0`